### PR TITLE
[SD-79] Expose deploying user in deploy hooks

### DIFF
--- a/lib/engineyard-serverside-adapter/arguments.rb
+++ b/lib/engineyard-serverside-adapter/arguments.rb
@@ -1,10 +1,15 @@
 module EY
   module Serverside
     class Adapter
-      class Arguments < Struct.new(:app, :config, :framework_env, :instances, :migrate, :ref, :repo, :stack, :verbose)
+      class Arguments < Struct.new(:app, :deploy_user, :config, :framework_env, :instances, :migrate, :ref, :repo, :stack, :verbose)
 
         def app=(app)
           enforce_nonempty!('app', app)
+          super
+        end
+
+        def deploy_user=(user)
+          enforce_nonempty!('deploy_user', user)
           super
         end
 

--- a/lib/engineyard-serverside-adapter/deploy.rb
+++ b/lib/engineyard-serverside-adapter/deploy.rb
@@ -4,6 +4,7 @@ module EY
       class Deploy < Action
 
         option :app,           :string,    :required => true
+        option :deploy_user,   :string,    :required => true
         option :stack,         :string,    :required => true
         option :instances,     :instances, :required => true
         option :config,        :json

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -4,6 +4,7 @@ shared_examples_for "a serverside action" do
   before(:each) do
     @adapter = described_class.new do |args|
       args.app           = 'app-from-adapter-new'
+      args.deploy_user   = 'testuser'
       args.instances     = [{:hostname => 'localhost', :roles => %w[a b c]}]
       args.framework_env = 'production'
       args.ref           = 'master'
@@ -55,6 +56,7 @@ shared_examples_for "a serverside action" do
     it "begins both commands with the given path" do
       adapter = described_class.new("/usr/local/grin") do |args|
         args.app           = 'app-from-adapter-new'
+        args.deploy_user   = 'testuser'
         args.instances     = [{:hostname => 'localhost', :roles => %w[a b c]}]
         args.framework_env = 'production'
         args.ref           = 'master'
@@ -105,6 +107,7 @@ describe EY::Serverside::Adapter do
     before(:each) do
       @adapter = described_class.new do |args|
         args.app           = 'app-from-adapter-new'
+        args.deploy_user   = 'testuser'
         args.instances     = [{:hostname => 'localhost', :roles => %w[a b c]}]
         args.framework_env = 'production'
         args.ref           = 'master'

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -4,6 +4,7 @@ describe EY::Serverside::Adapter::Deploy do
   it_should_behave_like "it installs engineyard-serverside"
 
   it_should_behave_like "it accepts app"
+  it_should_behave_like "it accepts deploy_user"
   it_should_behave_like "it accepts framework_env"
   it_should_behave_like "it accepts instances"
   it_should_behave_like "it accepts migrate"
@@ -13,6 +14,7 @@ describe EY::Serverside::Adapter::Deploy do
   it_should_behave_like "it accepts verbose"
 
   it_should_require :app
+  it_should_require :deploy_user
   it_should_require :instances
   it_should_require :framework_env
   it_should_require :ref
@@ -26,6 +28,7 @@ describe EY::Serverside::Adapter::Deploy do
     let(:command) do
       adapter = described_class.new do |arguments|
         arguments.app = "rackapp"
+        arguments.deploy_user = "testuser"
         arguments.framework_env = 'production'
         arguments.config = {'a' => 1}
         arguments.instances = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
@@ -42,7 +45,7 @@ describe EY::Serverside::Adapter::Deploy do
     end
 
     it "invokes exactly the right command" do
-      command.should == "engineyard-serverside _#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_ deploy --app rackapp --config '{\"a\":1}' --framework-env production --instance-names localhost:chewie --instance-roles localhost:han,solo --instances localhost --migrate 'rake db:migrate' --ref master --repo git@github.com:engineyard/engineyard-serverside.git --stack nginx_unicorn"
+      command.should == "engineyard-serverside _#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_ deploy --app rackapp --config '{\"a\":1}' --deploy-user testuser --framework-env production --instance-names localhost:chewie --instance-roles localhost:han,solo --instances localhost --migrate 'rake db:migrate' --ref master --repo git@github.com:engineyard/engineyard-serverside.git --stack nginx_unicorn"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ module ArgumentsHelpers
   def valid_options
     {
       :app           => 'rackapp',
+      :deploy_user   => 'testuser',
       :framework_env => 'production',
       :instances     => [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}],
       :ref           => 'master',
@@ -109,6 +110,7 @@ Spec::Runner.configure do |config|
     :ref           => '--ref',
     :repo          => '--repo',
     :migrate       => '--migrate',
+    :deploy_user   => '--deploy-user',
   }.each do |arg, switch|
     shared_examples_for "it accepts #{arg}" do
       it "puts the #{switch} arg in the command line" do


### PR DESCRIPTION
Pass the deploying user to engineyard-server side so this can be exposed
to the end user in deploy hooks.
