### PR TITLE
archive strategy

### DIFF
--- a/lib/engineyard-serverside-adapter.rb
+++ b/lib/engineyard-serverside-adapter.rb
@@ -14,11 +14,11 @@ module EY
       autoload :Restart,                'engineyard-serverside-adapter/restart'
       autoload :Rollback,               'engineyard-serverside-adapter/rollback'
 
-      def initialize(gem_bin_path = "")
+      def initialize(gem_bin_path = "", &block)
         @gem_bin_path = Pathname.new(gem_bin_path)
         @arguments    = Arguments.new
 
-        yield @arguments if block_given?
+        block.call(@arguments) if block
       end
 
       def deploy(&b)

--- a/lib/engineyard-serverside-adapter/action.rb
+++ b/lib/engineyard-serverside-adapter/action.rb
@@ -85,10 +85,19 @@ module EY
           @gem_bin_path.join(@serverside_bin_name).to_s
         end
 
+        # Initialize a command from arguments.
+        #
+        # Returns an instance of Command.
         def action_command
           Command.new(serverside_command_path, @serverside_version, *task) do |cmd|
             applicable_options.each do |option|
-              cmd.send("#{option.type}_argument", option.to_switch, @arguments[option.name])
+              value = @arguments[option.name]
+
+              # only options with a value or with `:include` are used as
+              # command flags.
+              if (!value && option.include?) || value
+                cmd.send("#{option.type}_argument", option.to_switch, value)
+              end
             end
           end
         end

--- a/lib/engineyard-serverside-adapter/arguments.rb
+++ b/lib/engineyard-serverside-adapter/arguments.rb
@@ -30,7 +30,8 @@ module EY
           end
         end
 
-        nonempty_writer :app, :environment_name, :account_name, :framework_env, :ref, :repo, :serverside_version, :stack
+        nonempty_writer :app, :environment_name, :account_name, :framework_env,
+          :ref, :repo, :serverside_version, :stack, :archive, :git
         writer :config, :migrate, :verbose
 
         def initialize(data={})

--- a/lib/engineyard-serverside-adapter/deploy.rb
+++ b/lib/engineyard-serverside-adapter/deploy.rb
@@ -11,9 +11,14 @@ module EY
         option :config,           :json
         option :verbose,          :boolean
         option :framework_env,    :string,    :required => true
-        option :ref,              :string,    :required => true
-        option :repo,             :string,    :required => true
-        option :migrate,          :string
+
+        option :migrate,          :string,    :include => true
+
+        option :ref,              :string
+        option :repo,             :string
+
+        option :git,              :string
+        option :archive,          :string
 
       private
 

--- a/lib/engineyard-serverside-adapter/option.rb
+++ b/lib/engineyard-serverside-adapter/option.rb
@@ -18,6 +18,13 @@ module EY
           !@version_requirement or @version_requirement.satisfied_by?(serverside_version)
         end
 
+        # Check if the option should always be included.
+        #
+        # Returns a boolean.
+        def include?
+          @options[:include]
+        end
+
         def required?
           @options[:required]
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ module ArgumentsHelpers
       :instances        => [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}],
       :ref              => 'master',
       :repo             => 'git@github.com:engineyard/engineyard-serverside.git',
+      :archive          => 'https://github.com/engineyard/engineyard-serverside/archive/master.zip',
       :stack            => 'nginx_unicorn',
     }
   end


### PR DESCRIPTION
Added `--git` and `--archive` flags the two different strategies.

Added an `include` option to better handle `--migrate '...'`/`--no-migrate`.

repo / ref no longer required, but there's no validation checking if either a repo or uri is required, should that be added?

\cc @martinemde 

related to engineyard/engineyard-serverside#57
