### PR TITLE
Require serverside_version for all commands and remove default version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,5 @@
+# ChangeLog
+
+## NEXT
+
+  * Require serverside_version for all commands.

--- a/lib/engineyard-serverside-adapter.rb
+++ b/lib/engineyard-serverside-adapter.rb
@@ -1,9 +1,9 @@
 require 'pathname'
+require 'engineyard-serverside-adapter/version'
 
 module EY
   module Serverside
     class Adapter
-      require 'engineyard-serverside-adapter/version'
       autoload :Action,                 'engineyard-serverside-adapter/action'
       autoload :Arguments,              'engineyard-serverside-adapter/arguments'
       autoload :Command,                'engineyard-serverside-adapter/command'

--- a/lib/engineyard-serverside-adapter/action.rb
+++ b/lib/engineyard-serverside-adapter/action.rb
@@ -29,7 +29,7 @@ module EY
 
           block.call @arguments if block
 
-          @serverside_version = Gem::Version.create(@arguments.serverside_version || ENGINEYARD_SERVERSIDE_VERSION.dup)
+          @serverside_version = @arguments.serverside_version
 
           validate!
         end
@@ -120,6 +120,10 @@ module EY
         end
 
         def validate!
+          unless @serverside_version
+            raise ArgumentError, "Required field [serverside_version] not provided."
+          end
+
           missing = required_options - given_options
           unless missing.empty?
             options_s = missing.map{|option| option.name}.join(', ')

--- a/lib/engineyard-serverside-adapter/arguments.rb
+++ b/lib/engineyard-serverside-adapter/arguments.rb
@@ -18,16 +18,9 @@ module EY
           end
         end
 
-        def self.aliased_attribute(pairs)
-          pairs.each do |from, to|
-            alias_method from, to
-            alias_method :"#{from}=", "#{to}="
-          end
-        end
-
         nonempty_attr_accessor :app, :account_name, :archive, :environment_name
-        nonempty_attr_accessor :framework_env, :git, :ref, :serverside_version, :stack
-        attr_accessor :config, :migrate, :verbose
+        nonempty_attr_accessor :framework_env, :git, :ref, :stack
+        attr_accessor :config, :migrate, :verbose, :serverside_version
         attr_reader :instances
         alias repo git # for versions where --repo is required, it is accessed via this alias
 
@@ -49,8 +42,10 @@ module EY
           @instances = instances
         end
 
-        # Uses Gem::Version.create to validate the version string
         def serverside_version=(value)
+          if value.nil? || value.to_s.empty?
+            raise ArgumentError, "Value for 'serverside_version' must be non-empty."
+          end
           @serverside_version = Gem::Version.create(value.dup) # dup b/c Gem::Version sometimes modifies its argument :(
         end
 

--- a/lib/engineyard-serverside-adapter/version.rb
+++ b/lib/engineyard-serverside-adapter/version.rb
@@ -2,10 +2,6 @@ module EY
   module Serverside
     class Adapter
       VERSION = "2.1.1.pre"
-      # For backwards compatibility, the serverside version default will be maintained until 2.1
-      # It is recommended that you supply a serverside_version to engineyard-serverside-adapter
-      # rather than relying on the default version here. This default will go away soon.
-      ENGINEYARD_SERVERSIDE_VERSION = ENV['ENGINEYARD_SERVERSIDE_VERSION'] || "2.3.0"
     end
   end
 end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -11,6 +11,7 @@ shared_examples_for "a serverside action" do
       args.ref              = 'master'
       args.git              = 'git@github.com:engineyard/engineyard-serverside.git'
       args.stack            = 'nginx_unicorn'
+      args.serverside_version = serverside_version
       args
     end
   end
@@ -88,6 +89,7 @@ shared_examples_for "a serverside action" do
         args.ref              = 'master'
         args.git              = 'git@github.com:engineyard/engineyard-serverside.git'
         args.stack            = 'nginx_unicorn'
+        args.serverside_version = serverside_version
         args
       end
 
@@ -154,6 +156,7 @@ describe EY::Serverside::Adapter do
         args.ref              = 'master'
         args.git              = 'git@github.com:engineyard/engineyard-serverside.git'
         args.stack            = 'nginx_unicorn'
+        args.serverside_version = serverside_version
       end
     end
 

--- a/spec/arguments_spec.rb
+++ b/spec/arguments_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe EY::Serverside::Adapter::Arguments do
   def raises_argument_error(message = nil, &block)
-    lambda {
+    expect {
       block.call(described_class.new)
-    }.should raise_error(ArgumentError, message)
+    }.to raise_error(ArgumentError, message)
   end
 
   it "raises an ArgumentError immediately when instances is empty" do
@@ -31,4 +31,13 @@ describe EY::Serverside::Adapter::Arguments do
     end
   end
 
+  it "raises an ArgumentError immediately when serverside_version is empty" do
+    raises_argument_error(/Value for 'serverside_version' must be non-empty/) do |arguments|
+      arguments.serverside_version = nil
+    end
+
+    raises_argument_error(/Value for 'serverside_version' must be non-empty/) do |arguments|
+      arguments.serverside_version = ''
+    end
+  end
 end

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -24,6 +24,7 @@ describe EY::Serverside::Adapter::Deploy do
   it_should_require :stack
   it_should_require :ref,  %w[1.6.4 2.0.0 2.1.0 2.2.0]
   it_should_require :git,  %w[1.6.4 2.0.0 2.1.0 2.2.0]
+  it_should_require :serverside_version
 
   it_should_ignore_requirement :environment_name, '1.6.4'
   it_should_ignore_requirement :account_name,     '1.6.4'
@@ -51,7 +52,7 @@ describe EY::Serverside::Adapter::Deploy do
         arguments.ref                = 'master'
         arguments.git                = 'git@github.com:engineyard/engineyard-serverside.git'
         arguments.stack              = "nginx_unicorn"
-        arguments.serverside_version = '2.3.0'
+        arguments.serverside_version = serverside_version
         block.call arguments if block
       end
       last_command(adapter)
@@ -68,7 +69,7 @@ describe EY::Serverside::Adapter::Deploy do
         arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
         arguments.migrate            = 'rake db:migrate'
         arguments.stack              = "nginx_unicorn"
-        arguments.serverside_version = '2.3.0'
+        arguments.serverside_version = serverside_version
         block.call arguments if block_given?
       end
       last_command(adapter)
@@ -81,7 +82,7 @@ describe EY::Serverside::Adapter::Deploy do
     it "invokes exactly the right command" do
       deploy_command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_#{serverside_version}_",
         "deploy",
         "--account-name ey",
         "--app rackapp",
@@ -174,16 +175,17 @@ describe EY::Serverside::Adapter::Deploy do
   context "with git deploy" do
     let(:command) do
       adapter = described_class.new do |arguments|
-        arguments.app              = "rackapp"
-        arguments.environment_name = 'rackapp_production'
-        arguments.account_name     = 'ey'
-        arguments.framework_env    = 'production'
-        arguments.config           = {'a' => 1}
-        arguments.instances        = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
-        arguments.migrate          = 'rake db:migrate'
-        arguments.ref              = 'master'
-        arguments.git              = 'git@github.com:engineyard/engineyard-serverside.git'
-        arguments.stack            = "nginx_unicorn"
+        arguments.app                = "rackapp"
+        arguments.environment_name   = 'rackapp_production'
+        arguments.account_name       = 'ey'
+        arguments.framework_env      = 'production'
+        arguments.config             = {'a' => 1}
+        arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.migrate            = 'rake db:migrate'
+        arguments.ref                = 'master'
+        arguments.git                = 'git@github.com:engineyard/engineyard-serverside.git'
+        arguments.stack              = "nginx_unicorn"
+        arguments.serverside_version = '2.3.0'
       end
       last_command(adapter)
     end
@@ -191,7 +193,7 @@ describe EY::Serverside::Adapter::Deploy do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_2.3.0_",
         "deploy",
         "--account-name ey",
         "--app rackapp",
@@ -220,7 +222,7 @@ describe EY::Serverside::Adapter::Deploy do
         args.migrate          = false
         args.stack            = "nginx_unicorn"
         args.archive          = 'https://github.com/engineyard/engineyard-serverside/archive/master.zip'
-        args.serverside_version = EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION
+        args.serverside_version = '2.3.0'
       end
 
       last_command(adapter)
@@ -229,7 +231,7 @@ describe EY::Serverside::Adapter::Deploy do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_2.3.0_",
         "deploy",
         "--account-name ey",
         "--app rackapp",
@@ -259,6 +261,7 @@ describe EY::Serverside::Adapter::Deploy do
         arguments.ref              = 'master'
         arguments.git              = 'git@github.com:engineyard/engineyard-serverside.git'
         arguments.stack            = "nginx_unicorn"
+        arguments.serverside_version = '2.3.0'
       end
       last_command(adapter)
     end
@@ -270,7 +273,7 @@ describe EY::Serverside::Adapter::Deploy do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_2.3.0_",
         "deploy",
         "--account-name ey",
         "--app rackapp",

--- a/spec/disable_maintenance_spec.rb
+++ b/spec/disable_maintenance_spec.rb
@@ -14,6 +14,7 @@ describe EY::Serverside::Adapter::DisableMaintenance do
   it_should_require :environment_name, %w[2.0.0 2.1.0 2.2.0 2.3.0]
   it_should_require :account_name,     %w[2.0.0 2.1.0 2.2.0 2.3.0]
   it_should_require :instances
+  it_should_require :serverside_version
 
   it_should_ignore_requirement :environment_name, '1.6.4'
   it_should_ignore_requirement :account_name,     '1.6.4'
@@ -24,10 +25,11 @@ describe EY::Serverside::Adapter::DisableMaintenance do
   context "with valid arguments" do
     let(:command) do
       adapter = described_class.new do |arguments|
-        arguments.app              = "rackapp"
-        arguments.environment_name = "rackapp_production"
-        arguments.account_name     = "ey"
-        arguments.instances        = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.app                = "rackapp"
+        arguments.environment_name   = "rackapp_production"
+        arguments.account_name       = "ey"
+        arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.serverside_version = serverside_version
       end
       last_command(adapter)
     end
@@ -35,7 +37,7 @@ describe EY::Serverside::Adapter::DisableMaintenance do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_#{serverside_version}_",
         "disable_maintenance",
         "--account-name ey",
         "--app rackapp",

--- a/spec/enable_maintenance_spec.rb
+++ b/spec/enable_maintenance_spec.rb
@@ -14,6 +14,7 @@ describe EY::Serverside::Adapter::EnableMaintenance do
   it_should_require :environment_name, %w[2.0.0 2.1.0 2.2.0 2.3.0]
   it_should_require :account_name,     %w[2.0.0 2.1.0 2.2.0 2.3.0]
   it_should_require :instances
+  it_should_require :serverside_version
 
   it_should_ignore_requirement :environment_name, '1.6.4'
   it_should_ignore_requirement :account_name,     '1.6.4'
@@ -25,10 +26,11 @@ describe EY::Serverside::Adapter::EnableMaintenance do
 
     let(:command) do
       adapter = described_class.new do |arguments|
-        arguments.app              = "rackapp"
-        arguments.environment_name = "rackapp_production"
-        arguments.account_name     = "ey"
-        arguments.instances        = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.app                = "rackapp"
+        arguments.environment_name   = "rackapp_production"
+        arguments.account_name       = "ey"
+        arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.serverside_version = serverside_version
       end
       last_command(adapter)
     end
@@ -36,7 +38,7 @@ describe EY::Serverside::Adapter::EnableMaintenance do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_#{serverside_version}_",
         "enable_maintenance",
         "--account-name ey",
         "--app rackapp",

--- a/spec/integrate_spec.rb
+++ b/spec/integrate_spec.rb
@@ -18,6 +18,7 @@ describe EY::Serverside::Adapter::Integrate do
   it_should_require :stack
   it_should_require :instances
   it_should_require :framework_env
+  it_should_require :serverside_version
 
   it_should_ignore_requirement :environment_name, '1.6.4'
   it_should_ignore_requirement :account_name,     '1.6.4'
@@ -28,12 +29,13 @@ describe EY::Serverside::Adapter::Integrate do
   context "with valid arguments" do
     let(:command) do
       adapter = described_class.new do |arguments|
-        arguments.app              = "rackapp"
-        arguments.environment_name = "rackapp_production"
-        arguments.account_name     = "ey"
-        arguments.instances        = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
-        arguments.stack            = "nginx_unicorn"
-        arguments.framework_env    = "production"
+        arguments.app                = "rackapp"
+        arguments.environment_name   = "rackapp_production"
+        arguments.account_name       = "ey"
+        arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.stack              = "nginx_unicorn"
+        arguments.framework_env      = "production"
+        arguments.serverside_version = serverside_version
       end
       last_command(adapter)
     end
@@ -41,7 +43,7 @@ describe EY::Serverside::Adapter::Integrate do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_#{serverside_version}_",
         "integrate",
         "--account-name ey",
         "--app rackapp",

--- a/spec/restart_spec.rb
+++ b/spec/restart_spec.rb
@@ -16,6 +16,7 @@ describe EY::Serverside::Adapter::Restart do
   it_should_require :account_name,     %w[2.0.0 2.1.0 2.2.0 2.3.0]
   it_should_require :instances
   it_should_require :stack
+  it_should_require :serverside_version
 
   it_should_ignore_requirement :environment_name, '1.6.4'
   it_should_ignore_requirement :account_name,     '1.6.4'
@@ -26,11 +27,12 @@ describe EY::Serverside::Adapter::Restart do
   context "with valid arguments" do
     let(:command) do
       adapter = described_class.new do |arguments|
-        arguments.app              = "rackapp"
-        arguments.environment_name = "rackapp_production"
-        arguments.account_name     = "ey"
-        arguments.instances        = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
-        arguments.stack            = "nginx_unicorn"
+        arguments.app                = "rackapp"
+        arguments.environment_name   = "rackapp_production"
+        arguments.account_name       = "ey"
+        arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.stack              = "nginx_unicorn"
+        arguments.serverside_version = serverside_version
       end
       last_command(adapter)
     end
@@ -38,7 +40,7 @@ describe EY::Serverside::Adapter::Restart do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_#{serverside_version}_",
         "restart",
         "--account-name ey",
         "--app rackapp",

--- a/spec/rollback_spec.rb
+++ b/spec/rollback_spec.rb
@@ -18,6 +18,7 @@ describe EY::Serverside::Adapter::Rollback do
   it_should_require :framework_env
   it_should_require :instances
   it_should_require :stack
+  it_should_require :serverside_version
 
   it_should_ignore_requirement :environment_name, '1.6.4'
   it_should_ignore_requirement :account_name,     '1.6.4'
@@ -28,13 +29,14 @@ describe EY::Serverside::Adapter::Rollback do
   context "with valid arguments" do
     let(:command) do
       adapter = described_class.new do |arguments|
-        arguments.app              = "rackapp"
-        arguments.environment_name = "rackapp_production"
-        arguments.account_name     = "ey"
-        arguments.framework_env    = 'production'
-        arguments.instances        = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
-        arguments.stack            = "nginx_unicorn"
-        arguments.config           = {'a' => 1}
+        arguments.app                = "rackapp"
+        arguments.environment_name   = "rackapp_production"
+        arguments.account_name       = "ey"
+        arguments.framework_env      = 'production'
+        arguments.instances          = [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}]
+        arguments.stack              = "nginx_unicorn"
+        arguments.config             = {'a' => 1}
+        arguments.serverside_version = serverside_version
       end
       last_command(adapter)
     end
@@ -46,7 +48,7 @@ describe EY::Serverside::Adapter::Rollback do
     it "invokes exactly the right command" do
       command.should == [
         "engineyard-serverside",
-        "_#{EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}_",
+        "_#{serverside_version}_",
         "deploy rollback",
         "--account-name ey",
         "--app rackapp",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,18 +4,30 @@ require 'bundler/setup'
 require 'engineyard-serverside-adapter'
 require 'pp'
 
+begin
+  specs = Gem::SpecFetcher.fetcher.fetch(Gem::Dependency.new("engineyard-serverside"))
+  ENGINEYARD_SERVERSIDE_VERSION = specs.map {|spec,| spec.version}.sort.last.to_s
+rescue
+  ENGINEYARD_SERVERSIDE_VERSION = '2.3.1'
+end
+
 module ArgumentsHelpers
+  def serverside_version
+    ENGINEYARD_SERVERSIDE_VERSION
+  end
+
   def valid_options
     {
-      :app              => 'rackapp',
-      :account_name     => 'ey',
-      #:archive          => 'https://github.com/engineyard/engineyard-serverside/archive/master.zip',
-      :environment_name => 'rackapp_production',
-      :framework_env    => 'production',
-      :git              => 'git@github.com:engineyard/engineyard-serverside.git',
-      :instances        => [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}],
-      :ref              => 'master',
-      :stack            => 'nginx_unicorn',
+      :app                => 'rackapp',
+      :account_name       => 'ey',
+      #:archive            => 'https://github.com/engineyard/engineyard-serverside/archive/master.zip',
+      :environment_name   => 'rackapp_production',
+      :framework_env      => 'production',
+      :git                => 'git@github.com:engineyard/engineyard-serverside.git',
+      :instances          => [{:hostname => 'localhost', :roles => %w[han solo], :name => 'chewie'}],
+      :ref                => 'master',
+      :stack              => 'nginx_unicorn',
+      :serverside_version => serverside_version,
     }
   end
 
@@ -110,14 +122,14 @@ RSpec.configure do |config|
 
       # of course, the only way to be sure is to actually run it, but
       # this gives us regression-proofing
-      version = EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION
+      version = serverside_version
       escaped_version = version.gsub(/\./, '\\.')
       installation_command.should == "(gem list engineyard-serverside | grep 'engineyard-serverside ' | egrep -q '#{escaped_version}[,)]') || (sudo sh -c 'cd `mktemp -d` && gem install engineyard-serverside --no-rdoc --no-ri -v #{version}')"
 
 
       installation_command.should =~ /gem list engineyard-serverside/
       installation_command.should =~ /egrep -q /
-      installation_command.should =~ /gem install engineyard-serverside.*-v #{Regexp.quote EY::Serverside::Adapter::ENGINEYARD_SERVERSIDE_VERSION}/
+      installation_command.should =~ /gem install engineyard-serverside.*-v #{Regexp.quote serverside_version}/
     end
   end
 


### PR DESCRIPTION
Follow through with deprecating the default serverside version.
