### PR TITLE
Maintenance actions have always supported --config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-  *
+  * Fixes a bug where maintenance actions incorrectly did not accept --config options.
 
 ## v2.3.0 (2014-06-02)
 

--- a/lib/engineyard-serverside-adapter/action/disable_maintenance.rb
+++ b/lib/engineyard-serverside-adapter/action/disable_maintenance.rb
@@ -5,6 +5,7 @@ module EY::Serverside
 
         option :app,              :string,    :required => true
         option :account_name,     :string,    :required => true, :version => '>=2.0.0'
+        option :config,           :json
         option :environment_name, :string,    :required => true, :version => '>=2.0.0'
         option :instance_names,   :hash,      :required => true
         option :instance_roles,   :hash,      :required => true

--- a/lib/engineyard-serverside-adapter/action/enable_maintenance.rb
+++ b/lib/engineyard-serverside-adapter/action/enable_maintenance.rb
@@ -5,6 +5,7 @@ module EY::Serverside
 
         option :app,              :string,    :required => true
         option :account_name,     :string,    :required => true, :version => '>=2.0.0'
+        option :config,           :json
         option :environment_name, :string,    :required => true, :version => '>=2.0.0'
         option :instance_names,   :hash,      :required => true
         option :instance_roles,   :hash,      :required => true

--- a/spec/disable_maintenance_spec.rb
+++ b/spec/disable_maintenance_spec.rb
@@ -4,6 +4,7 @@ describe EY::Serverside::Adapter::DisableMaintenance do
   it_should_behave_like "it installs engineyard-serverside"
 
   it_should_behave_like "it accepts app"
+  it_should_behave_like "it accepts account_name"
   it_should_behave_like "it accepts environment_name"
   it_should_behave_like "it accepts account_name"
   it_should_behave_like "it accepts instances"
@@ -21,6 +22,8 @@ describe EY::Serverside::Adapter::DisableMaintenance do
 
   it_should_exclude_from_command :environment_name, %w[1.6.4]
   it_should_exclude_from_command :account_name,     %w[1.6.4]
+
+  it_should_behave_like "it treats config as optional"
 
   context "with valid arguments" do
     let(:command) do

--- a/spec/enable_maintenance_spec.rb
+++ b/spec/enable_maintenance_spec.rb
@@ -4,6 +4,7 @@ describe EY::Serverside::Adapter::EnableMaintenance do
   it_should_behave_like "it installs engineyard-serverside"
 
   it_should_behave_like "it accepts app"
+  it_should_behave_like "it accepts account_name"
   it_should_behave_like "it accepts environment_name"
   it_should_behave_like "it accepts account_name"
   it_should_behave_like "it accepts instances"
@@ -21,6 +22,8 @@ describe EY::Serverside::Adapter::EnableMaintenance do
 
   it_should_exclude_from_command :environment_name, %w[1.6.4]
   it_should_exclude_from_command :account_name,     %w[1.6.4]
+
+  it_should_behave_like "it treats config as optional"
 
   context "with valid arguments" do
 


### PR DESCRIPTION
The adapter was incorrect in not including config with maintenance actions
